### PR TITLE
change of default value of the "urdf" argument

### DIFF
--- a/launch/world-empty.launch
+++ b/launch/world-empty.launch
@@ -10,7 +10,7 @@
   <arg name="debug" default="false"/>
   <arg name="verbose" default="true"/>
   <arg name="world" default="worlds/empty.world" />
-  <arg name="urdf" default="$(find hratc2017_framework)/description/urdf/pioneer3at.urdf.xacro" />
+  <arg name="urdf" default="$(find hratc2017_framework)/description/urdf/pioneer3at.urdf" />
   <arg name="joint_state_gui" default="false" />
   <arg name="joint_state_rate" default="1000" />
 


### PR DESCRIPTION
I changed the default value of argument "urdf". Using "<path_to_description>/pioneer3at.urdf", instead of, "<path_to_description>/pioneer3at.urdf.xacro". According to https://github.com/MobileRobots/amr-ros-config/blob/master/gazebo/example-pioneer3at-terrainworld.launch (at line 13) launch file of amr_robots_gazebo package, the input argument of xacro.py command is an .URDF file to generate a .XACRO file.